### PR TITLE
Added UDEV rules

### DIFF
--- a/99-ubaboot.rules
+++ b/99-ubaboot.rules
@@ -1,0 +1,21 @@
+# UDEV Rules for UbaBoot bootloader, https://github.com/rrevans/ubaboot
+#
+#
+# This file must be placed at:
+#
+# /etc/udev/rules.d/99-ubaboot.rules    (preferred location)
+#   or
+# /lib/udev/rules.d/99-ubaboot.rules    (req'd on some broken systems)
+#
+# To install, type this command in a terminal:
+#   sudo cp 99-ubaboot.rules /etc/udev/rules.d/99-ubaboot.rules
+#
+# After this file is installed, physically unplug and reconnect your board.
+#
+KERNEL=="hidraw*", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="611c", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="611c", MODE:="0666"
+
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ You must configure ubaboot to work with your board. See `config.h`.
     firmware; set `AVRDUDE_PROGRAMMER` in the `Makefile` for your programmer.
 6. Install a [udev
     rule](https://github.com/libusb/libusb/wiki/FAQ#can-i-run-libusb-applications-on-linux-without-root-privilege)
-    so you can use your device without root privilege.
+    so you can use your device without root privilege. If you use the default USB device ID, you can just copy the
+    file `99-ubaboot.rules` into `/etc/udev/rules.d`.
 7. Use `ubaboot.py` to load programs via the bootloader.
 
 ### Configuration overview


### PR DESCRIPTION
This MR adds a udev rules file, which can be copied directly
into /etc/udev/rules.d to be able to use the programmer without
root priviledges.