### PR TITLE
Add c programmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ You must configure ubaboot to work with your board. See `config.h`.
     so you can use your device without root privilege.
 7. Use `ubaboot.py` to load programs via the bootloader.
 
+Optionally, you can compile and use the C flasher, located inside the `c-programmer` folder. It uses only the
+C standard libraries, and libusb, so it is very portable.
+
 ### Configuration overview
 
 Required configuration:

--- a/c-programmer/Makefile
+++ b/c-programmer/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2023 by Raster Software Vigo (rastersoft@gmail.com)
+#
+# This file is part of ubaboot.
+#
+# ubaboot is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ubaboot is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ubaboot.  If not, see <http://www.gnu.org/licenses/>.
+
+UBABOOT_LIBS = libusb-1.0
+CFLAGS = -Os -g -Wall
+
+all: ubaboot
+
+clean:
+	rm -f *.o ubaboot
+
+read_hex.o: read_hex.c read_hex.h
+	gcc -c -o read_hex.o read_hex.c $(CFLAGS)
+
+ubaboot.o: ubaboot.c ubaboot.h ../config.h read_hex.h
+	gcc -c -o ubaboot.o ubaboot.c `pkg-config --cflags $(UBABOOT_LIBS)` $(CFLAGS)
+
+ubaboot: ubaboot.o read_hex.o
+	gcc -o ubaboot ubaboot.o read_hex.o `pkg-config --libs $(UBABOOT_LIBS)`

--- a/c-programmer/read_hex.c
+++ b/c-programmer/read_hex.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023 Raster Software Vigo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "read_hex.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static int line_number;
+static uint8_t crc;
+
+static uint8_t hex_to_bin(FILE *fd) {
+    uint8_t value, retval;
+
+    if (1 != fread(&value, 1, 1, fd)) {
+        return 0xFF;
+    }
+
+    if (value > 'Z') {
+        value -= 32; // transform into uppercase
+    }
+    if (value >= 'A') {
+        retval = value + 10 - 'A';
+    } else {
+        retval = value - '0';
+    }
+    if (retval > 15) {
+        return 0xFF;
+    } else {
+        return retval;
+    }
+}
+
+static bool read_hex_value(FILE *fd, uint8_t *value) {
+    uint8_t buffer[2];
+    buffer[0] = hex_to_bin(fd);
+    buffer[1] = hex_to_bin(fd);
+    if ((buffer[0] == 0xFF) || (buffer[1] == 0xFF)) {
+        fprintf(stderr, "Invalid hexadecimal value at line %d.\n", line_number);
+        return false;
+    }
+    *value = buffer[0] * 16 + buffer[1];
+    crc += *value;
+    return true;
+}
+
+static bool find_colon(FILE *fd) {
+    uint8_t value;
+    while (true) {
+        if (1 != fread(&value, 1, 1, fd)) {
+            return false;
+        }
+        if (value == ':') {
+            line_number++;
+            return true;
+        }
+    }
+}
+
+static hex_block* read_block(FILE *fd) {
+    hex_block *retval = NULL;
+    uint8_t tmp = 0, count, *p;
+
+    if (!find_colon(fd)) {
+        fprintf(stderr, "End-of-file block not found.\n");
+        return NULL;
+    }
+    retval = malloc(sizeof(hex_block));
+    if (retval == NULL) {
+        fprintf(stderr, "Unable to reserve memory block.\n");
+        return retval;
+    }
+    retval->next = NULL;
+    crc = 0;
+    if (!read_hex_value(fd, &tmp)) {
+        fprintf(stderr, "Failed to read the address at line %d.\n", line_number);
+        goto read_block_err;
+    }
+    retval->size = tmp;
+    if (!read_hex_value(fd, &tmp)) {
+        fprintf(stderr, "Failed to read the address at line %d.\n", line_number);
+        goto read_block_err;
+    }
+    retval->address = 256 * ((uint16_t)tmp);
+    if (!read_hex_value(fd, &tmp)) {
+        goto read_block_err;
+    }
+    retval->address += (uint16_t)tmp;
+    if (!read_hex_value(fd, &tmp)) {
+        fprintf(stderr, "Failed to read the block type at line %d.\n", line_number);
+        goto read_block_err;
+    }
+    retval->type = tmp;
+    if ((tmp != 0) && (tmp != 1)) {
+        fprintf(stderr, "Invalid block type %02X at line %d.\n", tmp, line_number);
+        goto read_block_err;
+    }
+    for(p = retval->data, count = 0; count < retval->size; count++, p++) {
+        if (!read_hex_value(fd, &tmp)) {
+            fprintf(stderr, "Failed to read value at line %d.\n", line_number);
+            goto read_block_err;
+        }
+        *p = tmp;
+    }
+    if (!read_hex_value(fd, &tmp)) {
+        fprintf(stderr, "Failed to read the CRC at line %d.\n", line_number);
+        goto read_block_err;
+    }
+    if (crc == 0) {
+        return retval;
+    } else {
+        fprintf(stderr, "Incorrect CRC value, %02X, at line %d.\n", crc, line_number);
+    }
+
+read_block_err:
+    free(retval);
+    return NULL;
+}
+
+void free_hex_blocks(hex_block *block) {
+    hex_block *tmp;
+    while(block) {
+        tmp = block->next;
+        free(block);
+        block = tmp;
+    }
+}
+
+hex_block* read_hex_file(FILE *fd) {
+    hex_block *blocks = NULL;
+    hex_block *last_block = NULL;
+    hex_block *block;
+
+    line_number = 0;
+
+    while (true) {
+        block = read_block(fd);
+        if (block == NULL) {
+            free_hex_blocks(blocks);
+            return NULL;
+        }
+        if (last_block == NULL) {
+            last_block = blocks = block;
+            continue;
+        }
+        last_block->next = block;
+        last_block = block;
+        if (block->type == 0x01) {
+            break;
+        }
+    }
+    return blocks;
+}

--- a/c-programmer/read_hex.h
+++ b/c-programmer/read_hex.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Raster Software Vigo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct _hex_block {
+    uint8_t size;
+    uint16_t address;
+    uint8_t type;
+    uint8_t data[256];
+    struct _hex_block *next;
+};
+
+typedef struct _hex_block hex_block;
+
+void free_hex_blocks(hex_block *block);
+hex_block* read_hex_file(FILE *fd);

--- a/c-programmer/ubaboot.c
+++ b/c-programmer/ubaboot.c
@@ -228,6 +228,7 @@ void help() {
     printf("    -r:                    if present, will retry once per second until the\n");
     printf("                           programming device is available.\n");
     printf("    -h:                    shows this help.\n");
+    printf("    -c:                    just return without error (useful to check that the binary exists).");
 }
 
 int main(int argc, char **argv) {
@@ -253,6 +254,8 @@ int main(int argc, char **argv) {
             break;
         case 'h':
             help();
+            return 0;
+        case 'c':
             return 0;
         default:
             help();
@@ -310,7 +313,7 @@ int main(int argc, char **argv) {
                                                  PRODUCT_ID);
         if (handle == NULL) {
             if (wait) {
-                fprintf(stderr, "Can't find the device. Retrying.\n");
+                fprintf(stderr, "Can't find Ubaboot. Please, press the RESET button in the device. Retrying.\n");
                 sleep(1);
             } else {
                 fprintf(stderr, "Can't find the device. Ensure that it's in programming mode.\n");

--- a/c-programmer/ubaboot.c
+++ b/c-programmer/ubaboot.c
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2023 Raster Software Vigo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libusb-1.0/libusb.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <unistd.h> // for "sleep()" and "usleep()"
+
+#include "../config.h"
+#include "ubaboot.h"
+#include "read_hex.h"
+
+static uint16_t FLASH_END = 0x7FFF;
+
+int dev_read(libusb_device_handle *handle, uint8_t request, unsigned char *data, uint16_t length) {
+    return libusb_control_transfer(handle, DEV_READ, request, 0, 0, data, length, 0);
+}
+
+int dev_write(libusb_device_handle *handle, uint8_t request, unsigned char *data, uint16_t length) {
+    return libusb_control_transfer(handle, DEV_WRITE, request, 0, 0, data, length, 0);
+}
+
+bool read_mem(libusb_device_handle *handle, uint8_t op, uint8_t *buffer, uint16_t address, uint32_t tsize, uint16_t blksize) {
+    uint32_t received = 0;
+    uint32_t remaining;
+    uint16_t bsz;
+
+    while (received < tsize) {
+        remaining = tsize - received;
+        bsz = (remaining < blksize) ? remaining : blksize;
+        if (bsz != libusb_control_transfer(handle, DEV_READ, op, address+received, 0, buffer+received, bsz, 0)) {
+            return false;
+        }
+        received += bsz;
+    }
+    return true;
+}
+
+bool write_mem(libusb_device_handle *handle, uint8_t op, uint8_t *buffer, uint16_t address, uint32_t tsize, uint16_t blksize) {
+    uint32_t sent = 0;
+    uint32_t remaining;
+    uint8_t *newbuffer;
+
+    while (sent < tsize) {
+        remaining = tsize - sent;
+        if (remaining < blksize) {
+            newbuffer = malloc(blksize);
+            memset(newbuffer, 0xFF, blksize);
+            memcpy(newbuffer, buffer + sent, remaining);
+        } else {
+            newbuffer = buffer+sent;
+        }
+        if (blksize != libusb_control_transfer(handle, DEV_WRITE, op, address+sent, 0, newbuffer, blksize, 0)) {
+            return false;
+        }
+        if (newbuffer != buffer+sent) {
+            free(newbuffer);
+        }
+        sent += blksize;
+        usleep(20000);
+    }
+    return true;
+}
+
+bool read_device_id(libusb_device_handle *handle, uint32_t *id) {
+    unsigned char buffer[3];
+
+    if (3 != dev_read(handle, GET_SIGNATURE, buffer, 3)) {
+        return false;
+    }
+    *id = (uint32_t) buffer[0];
+    *id <<= 8;
+    *id |= (uint32_t) buffer[1];
+    *id <<= 8;
+    *id |= (uint32_t) buffer[2];
+    return true;
+}
+
+bool read_fuses(libusb_device_handle *handle,
+                uint8_t *lock,
+                uint8_t *efuse,
+                uint8_t *hfuse,
+                uint8_t *lfuse) {
+    unsigned char buffer[4];
+
+    if (4 != dev_read(handle, GET_LOCK, buffer, 4)) {
+        return false;
+    }
+    *lfuse = buffer[0];
+    *lock  = buffer[1];
+    *efuse = buffer[2];
+    *hfuse = buffer[3];
+    return true;
+}
+
+bool reboot(libusb_device_handle *handle) {
+    return 0 != dev_write(handle, REBOOT, NULL, 0);
+}
+
+bool program_hex(libusb_device_handle *handle, char *filename) {
+    hex_block *blocks = NULL;
+    FILE *fd = fopen(filename, "r");
+    if (fd == NULL) {
+        fprintf(stderr, "Can't open the file %s\n", filename);
+        return false;
+    }
+    blocks = read_hex_file(fd);
+    if (blocks == NULL) {
+        return false;
+    }
+    return true;
+}
+
+int dump_flash(libusb_device_handle *handle, char *filename) {
+    bool first_line = true;
+    int counter = 0;
+    uint8_t crc = 0;
+    FILE *fd = stdout;
+    uint8_t memory[32768];
+
+    if (!read_mem(handle, READ_FLASH, memory, 0, FLASH_END + 1, 512)) {
+        fprintf(stderr, "Error while reading flash. Aborting.\n");
+        return -5;
+    }
+    if (filename != NULL) {
+        fd = fopen(filename, "w");
+        if (fd == NULL) {
+            fprintf(stderr, "Failed to open the filename %s to dump the memory. Aborting.\n", filename);
+            return -6;
+        }
+    }
+
+    for(uint8_t *p = memory; counter < FLASH_END + 1; p++, counter++) {
+        if (counter%16 == 0) {
+            if (!first_line) {
+                crc = 256 - crc;
+                fprintf(fd, "%02X\n", crc);
+            }
+            first_line = false;
+            fprintf(fd, ":10%04X00",counter);
+            crc = 16 + ((uint8_t)(counter % 256)) + ((uint8_t)(counter / 256));
+        }
+        fprintf(fd, "%02X", *p);
+        crc += *p;
+    }
+    crc = 256 - crc;
+    fprintf(fd, "%02X\n:00000001FF\n", crc);
+    return 0;
+}
+
+int program_flash(libusb_device_handle *handle, char *filename) {
+    hex_block *blocks = NULL, *pblock = NULL;
+    uint8_t memory[32768];
+    uint8_t memory2[32768];
+    int p;
+    uint16_t write_size = 0;
+
+    FILE *fd = fopen(filename, "r");
+    if (fd == NULL) {
+        fprintf(stderr, "Failed to open hexadecimal file %s. Aborting.\n", filename);
+        return -5;
+    }
+    blocks = read_hex_file(fd);
+    if (blocks == NULL) {
+        printf("Error\n");
+        return -5;
+    }
+    memset(memory, 0xFF, 32768);
+    for(pblock = blocks; pblock != NULL; pblock = pblock->next) {
+        memcpy(memory + pblock->address, pblock->data, pblock->size);
+        if ((pblock->address + pblock->size) > write_size) {
+            write_size = pblock->address + pblock->size;
+        }
+    }
+    if (write_size > (FLASH_END - 511)) {
+        fprintf(stderr, "ERROR: the code will overwrite the bootloader. Aborting.\n");
+        return -6;
+    }
+    fprintf(stderr, "Writing to flash %d bytes\n", write_size);
+    if (!write_mem(handle, WRITE_FLASH, memory, 0, write_size, 512)) {
+        fprintf(stderr, "Error while writing flash. Aborting.\n");
+        return -5;
+    }
+    fprintf(stderr, "Verifying data\n");
+    memset(memory2, 0xFF, 32768);
+    if (!read_mem(handle, READ_FLASH, memory2, 0, write_size, 512)) {
+        fprintf(stderr, "Error while verifing flash. Aborting.\n");
+        return -5;
+    }
+    for(p=0; p<write_size; p++) {
+        if (memory[p] != memory2[p]) {
+            fprintf(stderr, "Error while verifying flash at index %d (0x%04X). Aborting.\n", p, p);
+            return -5;
+        }
+    }
+    free_hex_blocks(blocks);
+    fprintf(stderr, "Flash correctly written. Rebooting.\n");
+    reboot(handle);
+    return 0;
+}
+
+void help() {
+    printf("Usage: ubaboot [-w] [-h] COMMAND\n");
+    printf("  Commands:\n");
+    printf("    reboot:                reboot the board and run main program.\n");
+    printf("    status:                returns the fuses and lock values.\n");
+    printf("    read flash [file.hex]: reads the program memory and shows it in\n");
+    printf("                           the screen or dumps it into a file.\n");
+    printf("    write flash file.hex:  writes the data in 'file.hex' into the program memory\n");
+    printf("    -r:                    if present, will retry once per second until the\n");
+    printf("                           programming device is available.\n");
+    printf("    -h:                    shows this help.\n");
+}
+
+int main(int argc, char **argv) {
+    libusb_context *ctx = NULL;
+    libusb_device_handle *handle;
+    uint8_t memory[4];
+    bool wait = false;
+    int param_index = 1;
+    enum Commands command;
+    char *filename = NULL;
+    uint32_t device_id;
+
+    if (argc < 2) {
+        help();
+        return -1;
+    }
+
+    if (argv[1][0] == '-') {
+        switch (argv[1][1]) {
+        case 'r':
+            wait = true;
+            param_index++;
+            break;
+        case 'h':
+            help();
+            return 0;
+        default:
+            help();
+            return -1;
+        }
+    }
+
+    if (LIBUSB_SUCCESS != libusb_init(&ctx)) {
+        fprintf(stderr, "Failed to initialize the USB library. Aborting.");
+        exit(-1);
+    }
+
+    if (!strcmp(argv[param_index], "reboot")) {
+        command = COMMAND_REBOOT;
+    } else if (!strcmp(argv[param_index], "status")) {
+        command = COMMAND_STATUS;
+    } else if (!strcmp(argv[param_index], "read")) {
+        if (argc < (param_index + 2)) {
+            help();
+            return -1;
+        }
+        if (!strcmp(argv[param_index+1], "flash")) {
+            command = COMMAND_READ_FLASH;
+        } else if(!strcmp(argv[param_index+1], "eeprom")) {
+            command = COMMAND_READ_EEPROM;
+        } else {
+            help();
+            return -1;
+        }
+        if (argc >= (param_index + 3)) {
+            filename = argv[param_index+2];
+        }
+    } else if (!strcmp(argv[param_index], "write")) {
+        if (argc < (param_index + 3)) {
+            help();
+            return -1;
+        }
+        if (!strcmp(argv[param_index+1], "flash")) {
+            command = COMMAND_WRITE_FLASH;
+        } else if(!strcmp(argv[param_index+1], "eeprom")) {
+            command = COMMAND_WRITE_EEPROM;
+        } else {
+            help();
+            return -1;
+        }
+        filename = argv[param_index+2];
+    } else {
+        help();
+        return -1;
+    }
+
+    do {
+        handle = libusb_open_device_with_vid_pid(ctx,
+                                                 VENDOR_ID,
+                                                 PRODUCT_ID);
+        if (handle == NULL) {
+            if (wait) {
+                fprintf(stderr, "Can't find the device. Retrying.\n");
+                sleep(1);
+            } else {
+                fprintf(stderr, "Can't find the device. Ensure that it's in programming mode.\n");
+                exit(-2);
+            }
+        } else {
+            break;
+        }
+    } while(1);
+
+
+    if (!read_device_id(handle, &device_id)) {
+        fprintf(stderr, "Can't read the device ID. Aborting.\n");
+        return -3;
+    }
+    if (device_id != 0x001E9587) {
+        fprintf(stderr, "Device ID is 0x%08X instead of 0x001E9587. Aborting.\n", device_id);
+        return -4;
+    }
+    fprintf(stderr, "CPU ID: %08X\n", device_id);
+
+
+    switch(command) {
+    case COMMAND_REBOOT:
+        reboot(handle);
+        return 0;
+    case COMMAND_STATUS:
+        if (!read_fuses(handle, memory, memory+1, memory+2, memory+3)) {
+            fprintf(stderr, "Failed to read the fuses.\n");
+            return -5;
+        }
+        fprintf(stderr, "Fuses: lfuse: 0x%02X; hfuse: 0x%02X; efuse: 0x%02X; lock: 0x%02X\n", memory[3], memory[2], memory[1], memory[0]);
+        return 0;
+    case COMMAND_READ_FLASH:
+        return dump_flash(handle, filename);
+    case COMMAND_WRITE_FLASH:
+        return program_flash(handle, filename);
+    default:
+        fprintf(stderr, "Command not yet implemented.\n");
+        return -1;
+    }
+}

--- a/c-programmer/ubaboot.h
+++ b/c-programmer/ubaboot.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Raster Software Vigo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define GET_SIGNATURE 1
+#define READ_FLASH 2
+#define WRITE_FLASH 3
+#define REBOOT 4
+#define READ_EEPROM 5
+#define WRITE_EEPROM 6
+#define GET_LOCK 7
+
+#define DEV_READ 0xC0
+#define DEV_WRITE 0x40
+
+enum Commands { COMMAND_REBOOT,
+                COMMAND_STATUS,
+                COMMAND_READ_FLASH,
+                COMMAND_READ_EEPROM,
+                COMMAND_WRITE_FLASH,
+                COMMAND_WRITE_EEPROM
+              };
+


### PR DESCRIPTION
This MR adds a flasher program written in C language. It only uses libusb, and the standard C libraries (and unistd for sleep() and usleep(), which should be easy to replace in Windows if needed). The advantage of this is that it would allow to include full support of ubaboot into QMK.